### PR TITLE
Patch to fix map rendering issue in Chrome

### DIFF
--- a/touch/src/Leaflet.js
+++ b/touch/src/Leaflet.js
@@ -245,6 +245,11 @@ Ext.define('Ext.Leaflet', {
     setMapCenter: function(coordinates) {
         var me = this,
             map = me.getMap();
+            
+        if (!map) {
+            me.renderMap();
+            map = me.getMap();
+        }
 
         if (map && coordinates) {
             if (!me.isPainted()) {


### PR DESCRIPTION
This patch fixes the map rendering issue in Chrom(e|ium). It should also fix it for Android.

I'm not entirely sure, but this file might belong to Leaflet.js or another external library, I'm trying to determine if it does. If it does, we may want to consider updating to a new version of the library where this issue may have been patched, vs using our own patched version. I looked at the leaflet.js source and didn't find anything conclusive but I'll look a little harder. I would rather use a newer version if possible than to maintain something like this ourselves.