### PR TITLE
Call `refresh()` on completion of `sync()`

### DIFF
--- a/app/controller/Groups.js
+++ b/app/controller/Groups.js
@@ -173,9 +173,9 @@ Ext.define('DevCycleMobile.controller.Groups', {
 
 		groupRiderStore.removeAll();
 		groupRiderStore.clearFilter(true);
-		groupRiderStore.sync();
-		//groupRiderStore.reload();
-		Ext.getCmp('myGroupsList').refresh();
+		groupRiderStore.sync({
+			callback: Ext.getCmp('myGroupsList').refresh
+		});
 		DevCycleMobile.app.getController('Map').removeGroup(group_code);
 	},
 


### PR DESCRIPTION
`sync()` is actually asynchronous, so immediately calling `refresh()`
doesn't ensure that the list on screen will be correctly populated.  The
`refresh` call is done at the completion of `sync()`, regardless of
whether or not that method was successful or not.