### PR TITLE
Splash screen! (Requires #37)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,15 @@ The above will provide you with a working build of the application that you can
 run.  Below you will find tasks which are someone outside of the normal
 development process, but are documented for future reference.
 
+### Configuring the splash screen
+To configure the splash screen properly (to show it for the full loading time
+of the app and to remove the Sencha splash screen), add the following
+line to cordova/config.xml in the top level:
+
+```
+<preference name="AutoHideSplashScreen" value="false" />
+```
+
 ### Setting up the App Icon
 Using the above instructions, the app will build using the default Cordova app
 icon. To change the app icon, edit `cordova/config.xml`.

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Add the following to the top level of the XML in cordova/config.xml:
 
     <preference name="AutoHideSplashScreen" value="false" />
 
-    <splash src="../resources/branding/drawapble-ldpi/splash.png" density="port-ldpi" width="480" height="800" />
+    <splash src="../resources/branding/drawable-ldpi/splash.png" density="port-ldpi" width="480" height="800" />
     <splash src="../resources/branding/drawable-mdpi/splash.png" density="port-mdpi" width="640" height="960" />
     <splash src="../resources/branding/drawable-hdpi/splash.png" density="port-hdpi" width="320" height="480" />
     <splash src="../resources/branding/drawable-xhdpi/splash.png" density="port-xhdpi" width="640" height="1136" />

--- a/README.md
+++ b/README.md
@@ -79,51 +79,33 @@ The above will provide you with a working build of the application that you can
 run.  Below you will find tasks which are someone outside of the normal
 development process, but are documented for future reference.
 
-### Configuring the splash screen
-To configure the splash screen properly (to show it for the full loading time
-of the app and to remove the Sencha splash screen), add the following
-line to cordova/config.xml in the top level:
+### Configuring the Splash Screen and App Icon
+
+Add the following to the top level of the XML in cordova/config.xml:
 
 ```
-<preference name="AutoHideSplashScreen" value="false" />
+    <icon src="../resources/branding/drawable-ldpi/icon.png" density="ldpi" width="36" height="36" />
+    <icon src="../resources/branding/drawable-mdpi/icon.png" density="mdpi" width="48" height="48" />
+    <icon src="../resources/branding/drawable-hdpi/icon.png" density="hdpi" width="72" height="72" />
+    <icon src="../resources/branding/drawable-xhdpi/icon.png" density="xhdpi" width="96" height="96" />
+    <icon src="../resources/branding/drawable/icon.png" />
+
+    <preference name="AutoHideSplashScreen" value="false" />
+
+    <splash src="../resources/branding/drawapble-ldpi/splash.png" density="port-ldpi" width="480" height="800" />
+    <splash src="../resources/branding/drawable-mdpi/splash.png" density="port-mdpi" width="640" height="960" />
+    <splash src="../resources/branding/drawable-hdpi/splash.png" density="port-hdpi" width="320" height="480" />
+    <splash src="../resources/branding/drawable-xhdpi/splash.png" density="port-xhdpi" width="640" height="1136" />
+    <splash src="../resources/branding/drawable/splash.png" />
 ```
 
-### Setting up the App Icon
-Using the above instructions, the app will build using the default Cordova app
-icon. To change the app icon, edit `cordova/config.xml`.
-
-In that file, add the following line in the top level of the xml:
-
-```
-<icon src="../resources/icons/Icon@2x.png" />
-```
-
-This may not be the optimal icon for all screen resolutions. If you have
-additional icons for different densities and sizes, you can and should add
-them as well by doing the following.
-
-For the Android app icon, add the following inside the
-`<platform name="android">` section:
-
-```
-        <icon src="../resources/icons/Icon.png" density="ldpi" />
-        <icon src="../resources/icons/Icon@2x.png" density="mdpi" />
-```
-
-Adjust the image paths as necessary for icons. The paths are relative to the
+Adjust the image paths as necessary. The paths are relative to the
 location of the config.xml file.
 
-For the iOS app icon, add the following inside the
-`<platform name="ios">` section:
-
-```
-        <icon src="../resources/icons/Icon.png" width="57" height="57" />
-        <icon src="../resources/icons/Icon@2x.png" width="114" height="114" />
-```
-
-As before, adjust the paths as necessary. The paths are relative to the
-location of the config.xml file. iOS also requires widths and heights to be
-specified for each icon.
+These set the splash screen and icon for all variants of the app. If you need
+to configure more specialized splashes or icons that are platform-specific,
+add these to the platform defined in the xml that they pertain to and edit
+accordingly.
 
 More information can be found at the
 [the Sencha forums](https://www.sencha.com/forum/showthread.php?279722-Sencha-PhoneGap-and-app-s-icon)

--- a/app.js
+++ b/app.js
@@ -89,12 +89,10 @@ Ext.application({
     isIconPrecomposed: true,
 
     startupImage: {
-        '320x460': 'resources/startup/320x460.jpg',
-        '640x920': 'resources/startup/640x920.png',
-        '768x1004': 'resources/startup/768x1004.png',
-        '748x1024': 'resources/startup/748x1024.png',
-        '1536x2008': 'resources/startup/1536x2008.png',
-        '1496x2048': 'resources/startup/1496x2048.png'
+        '320x480': 'resources/branding/drawable-hdpi/splash.png',
+        '480x800': 'resources/branding/drawable-ldpi/splash.png',
+        '640x960': 'resources/branding/drawable-mdpi/splash.png',
+        '640x1136': 'resources/branding/drawable-xhdpi/splash.png'
     },
 
     /**

--- a/fetchPlugins.py
+++ b/fetchPlugins.py
@@ -14,6 +14,10 @@ os.chdir("cordova")
 # Add the cordova device plugin
 subprocess.call("cordova -d plugin add https://github.com/apache/cordova-plugin-device.git", shell=True)
 
+# Add the cordova splash screen plugin
+subprocess.call("cordova -d plugin add https://github.com/apache/cordova-plugin-splashscreen.git", shell=True)
+
+
 # Add the tourtrak iOS plugin
 subprocess.call("cordova -d plugin add https://github.com/TourTrak/tourtrak-ios-plugin.git", shell=True)
 

--- a/index.html
+++ b/index.html
@@ -54,7 +54,13 @@
     </style>
     <!-- The line below must be kept intact for Sencha Command to build your application -->
     <script id="microloader" type="text/javascript" src=".sencha/app/microloader/development.js"></script>
-	
+    <script type="text/javascript" charset="utf-8">
+        document.addEventListener('deviceready', function() {
+         setTimeout(function() {
+         navigator.splashscreen.hide();
+         }, 1000);
+        });
+</script>
 </head>
 <body>
     <div id="appLoadingIndicator">


### PR DESCRIPTION
A few changes here:

* Add the cordova splashscreen plugin to the fetch plugins script
* Add javascript to manually hide the splash screen once the app is done loading to the index.html file
* Combine icon and splash instructions into one section of the readme with a big copypasta-able block of xml to set them up.

**Requires #37 which adds the branding directory to resources**

Once you have this branch pulled, run:

`cordova -d plugin add https://github.com/apache/cordova-plugin-splashscreen.git`

This has been added to the fetchPlugins.py script.